### PR TITLE
Switch to XHTML parser for forms to handle self-closing tags.

### DIFF
--- a/aib2ofx_lib/aib.py
+++ b/aib2ofx_lib/aib.py
@@ -57,7 +57,9 @@ class aib:
 
     def __init__(self, logindata, chatter):
         self.logindata = logindata
-        self.br = mechanize.Browser()
+        factory = mechanize.DefaultFactory()
+        factory._forms_factory = mechanize.FormsFactory(form_parser_class=mechanize.XHTMLCompatibleFormParser)
+        self.br = mechanize.Browser(factory=factory)
         self.quiet = chatter['quiet']
         self.debug = chatter['debug']
         br = self.br


### PR DESCRIPTION
AIB introduced some new content:

`<select name="selectProduct">
  <option value="0">Select a product:</option>
  <optgroup label="Loans ">
    <option value="onlineloan.htm">Personal / Car Loans</option>
  </optgroup>
  <optgroup label="Savings &amp; Investments-R32">
    <option value="onlinesaver.htm">Online Saver</option>
  </optgroup>
  <optgroup label="Insurance">
    <option value="http://www.aib.ie/personal/insurance/sl-aib-car-insurance ">Car Insurance</option>
    <option value="http://www.aib.ie/personal/insurance/sl-aib-health-insurance">Health Insurance</option>
    <option value="http://www.aib.ie/personal/insurance/sl-aib-home-insurance">Home Insurance</option>
  </optgroup>
  <optgroup label="Credit Cards"/>
  <optgroup label="Mortgages ">
    <option value="mortgages.htm">Mortgage 'Call Back'</option>
  </optgroup>
</select>`

The SGML parser chokes on the self closing "Credit Cards" element.  (actually the form parser dies, because only a closing tag is "seen" by the SGML parser)

The attached change switches to an XHTML parser which handles the self-closing tag correctly.  (I assume it emits an opening and closing tag event for a self-closing element)
