### PR TITLE
Skip pension accounts as they have a different layout.

### DIFF
--- a/aib2ofx_lib/aib.py
+++ b/aib2ofx_lib/aib.py
@@ -134,6 +134,11 @@ class aib:
         for account_line in main_page.findAll('ul', onclick=re.compile('.+')):
             if not account_line.span:
                 continue
+
+            # Skip pension accounts
+            if account_line.find('li', {'class': re.compile('i-umbrella')}):
+                continue
+
             account = {}
             account['accountId'] = account_line.span.renderContents()
             account['available'] = _toValue(


### PR DESCRIPTION
Don't think it makes sense to try to parse pension accounts,
they don't seem to have the same kind of information that normal
current or savings accounts have.

This skips pension accounts - which have an umbrella icon to
match the account type.